### PR TITLE
Return unused imports ordered by source location

### DIFF
--- a/src/zigimports.zig
+++ b/src/zigimports.zig
@@ -8,6 +8,12 @@ pub const ImportSpan = struct {
     start_column: usize,
     end_line: usize,
     end_column: usize,
+
+    // Compare ImportSpans by their source location.
+    fn lessThanByLocation(_: void, a: ImportSpan, b: ImportSpan) bool {
+        if (a.start_line == b.start_line) return a.start_column < b.start_column;
+        return a.start_line < b.start_line;
+    }
 };
 
 pub const BlockSpan = struct {
@@ -179,6 +185,9 @@ pub fn find_unused_imports(al: std.mem.Allocator, source: [:0]u8) !std.ArrayList
             try unused_imports.append(span);
         }
     }
+
+    // Order results by their source location.
+    std.sort.heap(ImportSpan, unused_imports.items, {}, ImportSpan.lessThanByLocation);
 
     return unused_imports;
 }


### PR DESCRIPTION
## Description

This PR implements ordering the results of `find_unused_imports` by source location.

Just a suggestion that I thought would be a nice addition to the tool. Also, I'm not sure if this is the best place to order the results.

Feel free to correct or edit it in anyway. Thanks for the awesome tool.

Sample output:

```
src/der.zig:4:0: big is unused
src/der.zig:5:0: builtin is unused
src/der.zig:11:0: Allocator is unused
src/der.zig:12:0: ArenaAllocator is unused
```