### PR TITLE
Sort used imports 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "Zig Container",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"context": ".."
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ziglang.vscode-zig",
+				"vmsynkov.colonize"
+			],
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "bash"
+			}
+		}
+	},
+	"postCreateCommand": "zig version",
+	// assuming rootless docker is being used
+	"remoteUser": "root"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use the Microsoft container for better devcontainer integration
+FROM mcr.microsoft.com/vscode/devcontainers/base:alpine
+
+# Install required tools
+RUN apk add --no-cache \
+    bash \
+    curl \
+    git \
+    build-base \
+    openssl-dev \
+    pkgconfig
+# Install Zig from the official website
+RUN curl -s https://ziglang.org/download/index.json | grep -o 'https://ziglang.org/download/[0-9.]*/zig-linux-x86_64-[0-9.]*.tar.xz' | head -n 1 | xargs curl -L -o /tmp/zig.tar.xz \
+    && mkdir -p /opt/zig \
+    && tar -xf /tmp/zig.tar.xz --strip-components=1 -C /opt/zig \
+    && ln -s /opt/zig/zig /usr/local/bin/zig \
+    && rm /tmp/zig.tar.xz
+# Install ZLS, the Zig language server
+RUN curl -s -LO https://builds.zigtools.org/zls-linux-x86_64-0.13.0.tar.xz && \
+    mkdir -p /opt/zls && \
+    tar -xf zls-linux-x86_64-0.13.0.tar.xz -C /opt/zls && \
+    ln -s /opt/zls/zls /usr/local/bin/zls  && \
+    rm zls-linux-x86_64-0.13.0.tar.xz
+# Set environment variables
+ENV PATH="/opt/zig:/opt/zls:$PATH"

--- a/README.md
+++ b/README.md
@@ -44,10 +44,55 @@ To tidy up your entire codebase, use:
 zigimports --fix .
 ```
 
+Inspired by `go fmt`, imports are sorted as follows:
+- Standard library libraries
+- Third-party modules
+- Local imports
+
+A newline is placed in between each group.
+
+```zig
+# Before
+const zig = @import("std").zig;
+const root = @import("root");
+const foo = @import("foo");
+const Two = @import("baz.zig").Two;
+const debug = @import("std").debug;
+const print = @import("std").debug.print;
+const bar = @import("bar");
+const One = @import("baz.zig").One;
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub fn hi() void {
+  print("hi");
+  One.add;
+  foo.bar();
+}
+
+pub fn bye() void {
+  print("bye");
+  builtin.is_test;
+}
+----------------------------------------
+# After
+const builtin = @import("builtin");
+const print = @import("std").debug.print;
+
+const foo = @import("foo");
+
+const One = @import("baz.zig").One;
+
+pub fn hi() void {
+  print("hi");
+  One.add;
+  foo.bar();
+}
+
+pub fn bye() void {
+  print("bye");
+  builtin.is_test;
+}
+```
 ## Development
 There is an optional [Dev Container](https://containers.dev/) configuration and Dockerfile to help setup Zig.
-
-## About this fork
-After using Zig for a couple weeks, I began to miss how `go fmt` automatically sorted imports and deleted unused ones. I started to investigate such capabilities and found tusharsadhwani's project. This was great but it was missing my desired feature of sorting imports.
-
-I was able to get a basic program for identifying and sorting imports that's heavily inspired by `go fmt`, then I I forked and integrated my changes in. The scope of the project was dramatically changed, so the refactor to get the changes in were too. I tried to do the commits in a sensible order.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ zigimports --fix .
 
 ## Development
 There is an optional [Dev Container](https://containers.dev/) configuration and Dockerfile to help setup Zig.
+
+## About this fork
+After using Zig for a couple weeks, I began to miss how `go fmt` automatically sorted imports and deleted unused ones. I started to investigate such capabilities and found tusharsadhwani's project. This was great but it was missing my desired feature of sorting imports.
+
+I was able to get a basic program for identifying and sorting imports that's heavily inspired by `go fmt`, then I I forked and integrated my changes in. The scope of the project was dramatically changed, so the refactor to get the changes in were too. I tried to do the commits in a sensible order.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the Zig compiler will simply ignore it.
 
 `zigimports` helps you avoid that by cleaning up unused imports.
 
-> [!NOTE] 
+> [!NOTE]
 > Zig plans to eventually address this issue in the compiler directly:
 > https://github.com/ziglang/zig/issues/335
 
@@ -43,3 +43,6 @@ To tidy up your entire codebase, use:
 ```bash
 zigimports --fix .
 ```
+
+## Development
+There is an optional [Dev Container](https://containers.dev/) configuration and Dockerfile to help setup Zig.

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,7 +15,7 @@ fn read_file(al: std.mem.Allocator, filepath: []const u8) ![:0]u8 {
     return source;
 }
 
-fn write_file(filepath: []const u8, chunks: [][]u8) !void {
+fn write_file(filepath: []const u8, chunks: [][]const u8) !void {
     const file = try std.fs.cwd().createFile(filepath, .{});
     defer file.close();
     const stat = try file.stat();

--- a/src/zigimports.zig
+++ b/src/zigimports.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const ImportKind = enum(u8) {
+pub const ImportKind = enum(u8) {
     Builtin,
     ThirdParty,
     Local,
@@ -438,6 +438,8 @@ pub fn newSourceFromImports(allocator: std.mem.Allocator, source: [:0]const u8, 
 
         line_start = actual_line_end;
     }
+
+    print("{s}\n", .{new_content.items});
 
     return new_content;
 }

--- a/src/zigimports.zig
+++ b/src/zigimports.zig
@@ -187,7 +187,7 @@ pub fn find_imports(al: std.mem.Allocator, source: [:0]const u8, debug: bool) ![
                     module = module[1 .. module.len - 1];
                     found_import = true;
                 }
-            } else if (found_import and (std.mem.eql(u8, token, ";") or std.mem.eql(u8, token, "."))) {
+            } else if (std.mem.eql(u8, token, ";") or std.mem.eql(u8, token, ".")) {
                 full_import_end = tree.tokenToSpan(token_idx + 1).end;
                 break;
             }
@@ -432,7 +432,9 @@ pub fn newSourceFromImports(allocator: std.mem.Allocator, source: [:0]const u8, 
             }
         }
 
+        print("line: {s}", .{});
         if (!is_import_line) {
+            print("added \n", .{});
             try new_content.appendSlice(line);
         }
 

--- a/src/zigimports.zig
+++ b/src/zigimports.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-
 pub const ImportKind = enum(u8) {
     Builtin,
     ThirdParty,
@@ -220,17 +219,6 @@ pub fn find_imports(al: std.mem.Allocator, source: [:0]const u8, debug: bool) ![
             end_index += 1;
             end_location.line += 1;
             end_location.column = 0;
-
-            // If the statement has at least two leading and at least two trailing
-            // newlines, then remove two trailing newlines.
-            // For well-formatted zig code, this will ensure that if the import was
-            // on its own little section surrounded by empty lines, the whole
-            // section is deleted.
-            if (start_index > 1 and source[start_index - 1] == '\n' and source[start_index - 2] == '\n' and source.len > end_index and source[end_index] == '\n') {
-                end_index += 1;
-                end_location.line += 1;
-                end_location.column = 0;
-            }
         }
 
         const span = ImportSpan{

--- a/src/zigimports.zig
+++ b/src/zigimports.zig
@@ -465,7 +465,7 @@ test "base-delete" {
     ;
 
     const imports = try find_imports(allocator, input, false);
-    defer imports.deinit();
+    defer allocator.free(imports);
 
     const unused_imports = try identifyUnusedImports(allocator, imports, input, false);
     defer unused_imports.deinit();

--- a/src/zigimports.zig
+++ b/src/zigimports.zig
@@ -90,12 +90,6 @@ fn is_inside_block(blocks: []BlockSpan, source_pos: usize) bool {
     return false;
 }
 
-pub fn find_unused_imports(al: std.mem.Allocator, source: [:0]const u8, debug: bool) !std.ArrayList(ImportSpan) {
-    const imports = try find_imports(al, source, debug);
-    defer al.free(imports);
-    return try identifyUnusedImports(al, imports, source, debug);
-}
-
 pub fn find_imports(al: std.mem.Allocator, source: [:0]const u8, debug: bool) ![]ImportSpan {
     var tree = try std.zig.Ast.parse(al, source, .zig);
     defer tree.deinit(al);
@@ -384,7 +378,10 @@ test "base-delete" {
         \\
     ;
 
-    const unused_imports = try find_unused_imports(allocator, input, false);
+    const imports = try find_imports(allocator, input, false);
+    defer imports.deinit();
+
+    const unused_imports = try identifyUnusedImports(allocator, imports, input, false);
     defer unused_imports.deinit();
 
     const new_chunks = try remove_imports(allocator, input, unused_imports.items, false);


### PR DESCRIPTION
Hi! I found your project and made a bunch of changes so that instead of just deleting unused imports, it now tracks used imports too and sorts them in an opinionated way, inspired by `go fmt`. 

I've been using `zigimports` during development of a different Zig project I am working on and ironed out the obvious bugs. I think my changes work, but this is the first Zig code base I've worked on so I'm sure there's improvements to make.

There's other changes in the PR that you might not want, like the Dev Container stuff, or function renaming I did to satisfy the Zig style guide. There's unit tests too.

Anyway, I wanted to reach back upstream to see your interest in expanding the scope of your program to manage used imports as well.  I tried to leave a commit history that refactored first and left the program in a running state each time before adding import sorting in 331bf60afca05c6165c7104650b879f7fd8c83b7. I don't expect this PR to merge as-is, but it's a starting point.

Thanks for the code! It was a great foundation for what I wanted to do.

